### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD tailscale /app/tailscale
 
 # build modified derper
 RUN cd /app/tailscale/cmd/derper && \
-    /usr/local/go/bin/go build -buildvcs=false -ldflags "-s -w" -o /app/derper && \
+    CGO_ENABLED=0 /usr/local/go/bin/go build -buildvcs=false -ldflags "-s -w" -o /app/derper && \
     cd /app && \
     rm -rf /app/tailscale
 


### PR DESCRIPTION
![image](https://github.com/yangchuansheng/ip_derper/assets/41264693/82841e14-03af-466b-8158-28024d054dd6)

在 debian 下会报这个错误，似乎是因为 docker 的 glibc 版本不匹配，编译的时候加入 `CGO_ENABLED=0` 即可解决